### PR TITLE
primitive multiply and mdivide_left_tri

### DIFF
--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -149,6 +149,10 @@ class opencl_context_base {
     // Used in math/rev/mat/fun/cholesky_decompose
     int cholesky_rev_min_block_size = 512;
     int cholesky_rev_block_partition = 8;
+    // Used in math/prim/mat/fun/multiply and
+    // math/rev/mat/fun/multiply
+    int multiply_size_worth_transfer = 1;
+    int lower_tri_inverse_size_worth_transfer = 1;
   } tuning_opts_;
 
   static opencl_context_base& getInstance() {

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -151,7 +151,8 @@ class opencl_context_base {
     int cholesky_rev_block_partition = 8;
     // Used in math/prim/mat/fun/multiply and
     // math/rev/mat/fun/multiply
-    int multiply_size_worth_transfer = 1;
+    int multiply_result_size_worth_transfer = 250000;
+    int multiply_common_dim_worth_transfer = 100;
     int lower_tri_inverse_size_worth_transfer = 1;
   } tuning_opts_;
 

--- a/stan/math/opencl/opencl_context.hpp
+++ b/stan/math/opencl/opencl_context.hpp
@@ -153,7 +153,7 @@ class opencl_context_base {
     // math/rev/mat/fun/multiply
     int multiply_result_size_worth_transfer = 250000;
     int multiply_common_dim_worth_transfer = 100;
-    int lower_tri_inverse_size_worth_transfer = 1;
+    int lower_tri_inverse_size_worth_transfer = 500;
   } tuning_opts_;
 
   static opencl_context_base& getInstance() {

--- a/stan/math/prim/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_tri.hpp
@@ -107,7 +107,6 @@ inline Eigen::Matrix<double, R1, C1> mdivide_left_tri(
   check_square("mdivide_left_tri", "A", A);
   if (A.rows() >= 
       opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer) {
-    std::cout << "abc" << std::endl;
     matrix_cl A_cl(A);
     auto Ainv_cl = lower_triangular_inverse(A_cl);
     Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> Ainv(A.rows(),

--- a/stan/math/prim/mat/fun/mdivide_left_tri.hpp
+++ b/stan/math/prim/mat/fun/mdivide_left_tri.hpp
@@ -6,7 +6,12 @@
 #include <stan/math/prim/mat/fun/promote_common.hpp>
 #include <stan/math/prim/mat/err/check_multiplicable.hpp>
 #include <stan/math/prim/mat/err/check_square.hpp>
-
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/opencl_context.hpp>
+#include <stan/math/opencl/multiply.hpp>
+#include <stan/math/opencl/lower_tri_inverse.hpp>
+#include <stan/math/opencl/copy.hpp>
+#endif
 namespace stan {
 namespace math {
 
@@ -51,6 +56,73 @@ inline Eigen::Matrix<T, R1, C1> mdivide_left_tri(
   A.template triangularView<TriView>().solveInPlace(b);
   return b;
 }
+
+#ifdef STAN_OPENCL
+/**
+ * Returns the solution of the system Ax=b when A is triangular
+ * @param A Triangular matrix.  Specify upper or lower with TriView
+ * being Eigen::Upper or Eigen::Lower.
+ * @param b Right hand side matrix or vector.
+ * @return x = A^-1 b, solution of the linear system.
+ * @throws std::domain_error if A is not square or the rows of b don't
+ * match the size of A.
+ */
+template <int TriView, int R1, int C1, int R2, int C2>
+inline Eigen::Matrix<double, R1, C2>
+mdivide_left_tri(const Eigen::Matrix<double, R1, C1> &A,
+                 const Eigen::Matrix<double, R2, C2> &b) {
+  check_square("mdivide_left_tri", "A", A);
+  check_multiplicable("mdivide_left_tri", "A", A, "b", b);
+  if (A.rows() >= 
+      opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer) {
+    return promote_common<Eigen::Matrix<double, R1, C1>, Eigen::Matrix<double, R1, C1> >(
+             A)
+      .template triangularView<TriView>()
+      .solve(
+          promote_common<Eigen::Matrix<double, R2, C2>, Eigen::Matrix<double, R2, C2> >(
+              b));
+  } else {
+    return promote_common<Eigen::Matrix<double, R1, C1>, Eigen::Matrix<double, R1, C1> >(
+             A)
+      .template triangularView<TriView>()
+      .solve(
+          promote_common<Eigen::Matrix<double, R2, C2>, Eigen::Matrix<double, R2, C2> >(
+              b));  
+  }  
+}
+
+/**
+ * Returns the solution of the system Ax=b when A is triangular and b=I.
+ * @param A Triangular matrix.  Specify upper or lower with TriView
+ * being Eigen::Upper or Eigen::Lower.
+ * @return x = A^-1 .
+ * @note Because OpenCL only works on doubles there are two
+ * <code>mdivide_left_tri(A)</code> functions. One that works on doubles
+ * (this one) and another that works on all other types.
+ * @throws std::domain_error if A is not square
+ */
+template <int TriView, int R1, int C1>
+inline Eigen::Matrix<double, R1, C1> mdivide_left_tri(
+    const Eigen::Matrix<double, R1, C1> &A) {
+  check_square("mdivide_left_tri", "A", A);
+  if (A.rows() >= 
+      opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer) {
+    std::cout << "abc" << std::endl;
+    matrix_cl A_cl(A);
+    auto Ainv_cl = lower_triangular_inverse(A_cl);
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> Ainv(A.rows(),
+                                                                 A.cols());
+    copy(Ainv, Ainv_cl);  // NOLINT
+    return Ainv;
+  } else {
+    int n = A.rows();
+    Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> b;
+    b.setIdentity(n, n);
+    A.template triangularView<TriView>().solveInPlace(b);
+    return b;
+  }  
+}
+#endif
 
 }  // namespace math
 }  // namespace stan

--- a/stan/math/prim/mat/fun/multiply.hpp
+++ b/stan/math/prim/mat/fun/multiply.hpp
@@ -59,9 +59,11 @@ inline Eigen::Matrix<double, R1, C2> multiply(
     const Eigen::Matrix<double, R2, C2>& m2) {
   check_multiplicable("multiply", "m1", m1, "m2", m2);
 #ifdef STAN_OPENCL
-  //TODO(Rok, Steve): determine what would be the check
-  if (m1.rows() >= opencl_context.tuning_opts().multiply_size_worth_transfer ||
-      m2.cols() >= opencl_context.tuning_opts().multiply_size_worth_transfer) {
+  //TODO(Rok, Steve): determine the sizes for this checks
+  if (((m1.rows() * m2.cols())
+        >= opencl_context.tuning_opts().multiply_result_size_worth_transfer) &&
+       (m1.cols()
+        > opencl_context.tuning_opts().multiply_common_dim_worth_transfer)) {
     matrix_cl m1_cl(m1);
     matrix_cl m2_cl(m2);
     auto m3_cl = m1_cl * m2_cl;

--- a/test/unit/math/prim/mat/fun/mdivide_left_tri_test.cpp
+++ b/test/unit/math/prim/mat/fun/mdivide_left_tri_test.cpp
@@ -1,6 +1,9 @@
 #include <stan/math/prim/mat.hpp>
 #include <gtest/gtest.h>
-
+#ifdef STAN_OPENCL
+#include <stan/math/opencl/opencl_context.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#endif
 TEST(MathMatrix, mdivide_left_tri_val) {
   using stan::math::mdivide_left_tri;
   stan::math::matrix_d Ad(2, 2);
@@ -30,3 +33,106 @@ TEST(MathMatrix, mdivide_left_tri_val) {
   EXPECT_NEAR(0.0, I(1, 0), 1.0E-12);
   EXPECT_NEAR(1.0, I(1, 1), 1.0e-12);
 }
+
+#ifdef STAN_OPENCL
+#define EXPECT_MATRIX_NEAR(A, B, DELTA) \
+  for (int i = 0; i < A.size(); i++)    \
+    EXPECT_NEAR(A(i), B(i), DELTA);
+TEST(MathMatrix, mdivide_left_tri_val_lower_opencl) {
+  using stan::math::mdivide_left_tri;
+  boost::random::mt19937 rng;
+  
+  stan::math::opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer = 1;
+  
+  int size = 512;
+  
+  auto m1 = stan::math::matrix_d::Zero(size, size).eval();
+  for(int i= 0;i<size;i++){
+    for(int j= 0;j<i;j++){
+      m1(i, j) = stan::math::normal_rng(-2, 2, rng);
+    }
+    m1(i,i) = 100;
+  }
+  
+  auto m1_inv_cl = stan::math::mdivide_left_tri<Eigen::Lower>(m1);
+  // to make sure we dont use OpenCL
+  stan::math::opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer = 1024;
+
+  auto m1_inv = stan::math::mdivide_left_tri<Eigen::Lower>(m1);
+  EXPECT_MATRIX_NEAR(m1_inv, m1_inv_cl, 1e-10);
+}
+
+TEST(MathMatrix, mdivide_left_tri_val_opencl) {
+  using stan::math::mdivide_left_tri;
+  boost::random::mt19937 rng;
+  
+  stan::math::opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer = 1;
+  
+  int size = 512;
+  
+  auto m1 = stan::math::matrix_d::Zero(size, size).eval();
+  for(int i= 0;i<size;i++){
+    for(int j= 0;j<i;j++){
+      m1(i, j) = stan::math::normal_rng(-2, 2, rng);
+    }
+    m1(i,i) = 100;
+  }
+  
+  auto m1_inv_cl = stan::math::mdivide_left_tri<Eigen::Upper>(m1);
+  // to make sure we dont use OpenCL
+  stan::math::opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer = 1024;
+
+  auto m1_inv = stan::math::mdivide_left_tri<Eigen::Upper>(m1);
+  EXPECT_MATRIX_NEAR(m1_inv, m1_inv_cl, 1e-10);
+}
+
+TEST(MathMatrix, mdivide_left_tri_right_side_lower_opencl) {
+  using stan::math::mdivide_left_tri;
+  boost::random::mt19937 rng;  
+  stan::math::opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer = 1;
+  
+  int size = 512;
+  
+  auto m1 = stan::math::matrix_d::Zero(size, size).eval();
+  auto m2 = stan::math::matrix_d::Identity(size, size).eval();
+  for(int i= 0;i<size;i++){
+    for(int j= 0;j<i;j++){
+      m1(i, j) = stan::math::normal_rng(-2, 2, rng);
+    }
+    m1(i,i) = 100;
+  }
+  
+  auto m1_inv_cl = stan::math::mdivide_left_tri<Eigen::Lower>(m1, m1);
+
+  stan::math::opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer = 1000;
+
+  auto m1_inv = stan::math::mdivide_left_tri<Eigen::Lower>(m1, m1);
+    
+  EXPECT_MATRIX_NEAR(m1_inv, m1_inv_cl, 1e-10);
+}
+
+TEST(MathMatrix, mdivide_left_tri_right_side_upper_opencl) {
+  using stan::math::mdivide_left_tri;
+  boost::random::mt19937 rng;  
+  stan::math::opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer = 1;
+  
+  int size = 512;
+  
+  auto m1 = stan::math::matrix_d::Zero(size, size).eval();
+  auto m2 = stan::math::matrix_d::Identity(size, size).eval();
+  for(int i= 0;i<size;i++){
+    for(int j= 0;j<i;j++){
+      m1(i, j) = stan::math::normal_rng(-2, 2, rng);
+    }
+    m1(i,i) = 100;
+  }
+  
+  auto m1_inv_cl = stan::math::mdivide_left_tri<Eigen::Upper>(m1, m1);
+
+  stan::math::opencl_context.tuning_opts().lower_tri_inverse_size_worth_transfer = 1000;
+
+  auto m1_inv = stan::math::mdivide_left_tri<Eigen::Upper>(m1, m1);
+    
+  EXPECT_MATRIX_NEAR(m1_inv, m1_inv_cl, 1e-10);
+}
+#endif

--- a/test/unit/math/prim/mat/fun/multiply_test.cpp
+++ b/test/unit/math/prim/mat/fun/multiply_test.cpp
@@ -145,24 +145,21 @@ TEST(AgradRevMatrix, multiply_vector_int) {
     EXPECT_NEAR(A(i), B(i), DELTA);
 
 TEST(MathMatrix, multiply_opencl) {
-  int tmp_size =
-    stan::math::opencl_context.tuning_opts().multiply_size_worth_transfer;
-  stan::math::opencl_context.tuning_opts().multiply_size_worth_transfer = 1;
+  stan::math::opencl_context.tuning_opts().multiply_result_size_worth_transfer = 1;
+  stan::math::opencl_context.tuning_opts().multiply_common_dim_worth_transfer = 1;
   using stan::math::multiply;
   int size = 512;
   auto m1 = stan::math::matrix_d::Random(size, size).eval();
   auto m2 = stan::math::matrix_d::Random(size, size).eval();
   
   auto m3_cl = multiply(m1, m2);
-
-  stan::math::opencl_context.tuning_opts().multiply_size_worth_transfer = 1024;
+  // to make sure we dont use OpenCL
+  stan::math::opencl_context.tuning_opts().multiply_result_size_worth_transfer = 100000000000;
+  stan::math::opencl_context.tuning_opts().multiply_common_dim_worth_transfer = 100000000000;
 
   auto m3 = multiply(m1, m2);
 
   EXPECT_MATRIX_NEAR(m3_cl, m3, 1e-10);
-
-  stan::math::opencl_context.tuning_opts().multiply_size_worth_transfer =
-    tmp_size;
 }
 
 #endif


### PR DESCRIPTION
A dummy PR to discuss how we want to handle `prim/multiply` & `prim/mdivide_left_tri` that we would want to merge next as no new kernels need to be added for them to be exposed. 

The only thing left to discuss is what should the default input sizes where we switch to OpenCL be.